### PR TITLE
Add URL to Playwright scrape results and refactor service code

### DIFF
--- a/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
+++ b/apps/api/src/scraper/scrapeURL/engines/playwright/index.ts
@@ -23,6 +23,7 @@ export async function scrapeURLWithPlaywright(
     logger: meta.logger.child("scrapeURLWithPlaywright/robustFetch"),
     schema: z.object({
       content: z.string(),
+      url: z.string(),
       pageStatusCode: z.number(),
       pageError: z.string().optional(),
       contentType: z.string().optional(),
@@ -36,7 +37,7 @@ export async function scrapeURLWithPlaywright(
   }
 
   return {
-    url: meta.rewrittenUrl ?? meta.url, // TODO: impove redirect following
+    url: response.url ?? meta.rewrittenUrl ?? meta.url, // TODO: impove redirect following
     html: response.content,
     statusCode: response.pageStatusCode,
     error: response.pageError,

--- a/apps/playwright-service-ts/api.ts
+++ b/apps/playwright-service-ts/api.ts
@@ -147,6 +147,7 @@ const scrapePage = async (page: Page, url: string, waitUntil: 'load' | 'networki
   }
 
   return {
+    url: response ? response.url() : url,
     content,
     status: response ? response.status() : null,
     headers,
@@ -240,6 +241,7 @@ app.post('/scrape', async (req: Request, res: Response) => {
   await requestContext.close();
 
   res.json({
+    url: result.url,
     content: result.content,
     pageStatusCode: result.status,
     contentType: result.contentType,


### PR DESCRIPTION
- Include response URL in scrape results for better redirect handling
- Reformat code for consistency and readability
- Improve logging and error messages in scrape endpoint
- Add media blocking and ad domain routing logic in browser context

Add URL to Playwright scrape results and refactor service code Add URL to Playwright scrape results and refactor service code